### PR TITLE
[ADDED] all the data mart tables which have at minimum a time filter

### DIFF
--- a/models/_models.yml
+++ b/models/_models.yml
@@ -12,6 +12,5 @@ models:
       - name: ccs_description_with_covid
       - name: condition_date_year
       - name: condition_date_year_month
-      - name: encounter_count
       - name: claim_count
       - name: claim_paid_amount_sum

--- a/models/ed_summary.sql
+++ b/models/ed_summary.sql
@@ -1,27 +1,15 @@
-/*
-Total conditions, encounters, claims, patients, cost by ED classification
-*/
-
 -- {{ config(enabled=var('ed_classification_enabled',var('tuva_packages_enabled',True))) }}
 
-with summary as (
-   select
-     classification_order
-     , classification_name
-     --, ccs_description_with_covid
-     , count(*) as condition_row_count
-     , count(distinct(encounter_id)) as encounter_count
-     , count(distinct(claim_id)) as claim_count
-     , count(distinct(patient_id)) as patient_count
-     , sum(claim_paid_amount_sum) as claim_paid_amount_sum
-   from {{ ref('ed_classification__johnston_conditions_with_class') }}
-   inner join {{ ref('ed_classification_categories') }} using(classification)
-   group by 1,2
-)
-
 select
-    summary.*
-    , 100 * ratio_to_report(claim_count) over() as percent_claim_row_count
-    , 100 * ratio_to_report(claim_paid_amount_sum) over() as percent_claim_paid_amount_sum
-from summary
-order by classification_order asc
+  classification_order
+  , classification_name
+  , ccs_description_with_covid
+  , condition_date_year
+  , condition_date_year_month
+  , count(distinct(encounter_id)) as encounter_count
+  , count(distinct(claim_id)) as claim_count
+  , sum(claim_paid_amount_sum) as claim_paid_amount_sum
+
+from {{ ref('ed_classification__johnston_conditions_with_class') }}
+inner join {{ ref('ed_classification_categories') }} using(classification)
+group by 1, 2, 3, 4, 5, 6

--- a/models/ed_summary.sql
+++ b/models/ed_summary.sql
@@ -6,10 +6,9 @@ select
   , ccs_description_with_covid
   , condition_date_year
   , condition_date_year_month
-  , count(distinct(encounter_id)) as encounter_count
   , count(distinct(claim_id)) as claim_count
   , sum(claim_paid_amount_sum) as claim_paid_amount_sum
 
 from {{ ref('ed_classification__johnston_conditions_with_class') }}
 inner join {{ ref('ed_classification_categories') }} using(classification)
-group by 1, 2, 3, 4, 5, 6
+group by 1, 2, 3, 4, 5

--- a/models/intermediate/ed_classification__johnston_conditions_with_class.sql
+++ b/models/intermediate/ed_classification__johnston_conditions_with_class.sql
@@ -6,9 +6,20 @@ any rows that were not classified.
 
 -- {{ config(enabled=var('ed_classification_enabled',var('tuva_packages_enabled',True))) }}
 
-
 select
-   *
+   a.encounter_id
+   , a.claim_id
+   , a.patient_id
+   , a.code_type
+   , a.code
+   , a.description
+   , a.ccs_description_with_covid
+   , a.condition_date
+   , {{ dbt_date.date_part("year", "condition_date") }}::text as condition_date_year
+   , {{ dbt_date.date_part("year", "condition_date") }}::text
+     || lpad({{ dbt_date.date_part("month", "condition_date") }}::text, 2, '0')
+     as condition_date_year_month
+   , a.claim_paid_amount_sum
    , case greatest(edcnnpa, edcnpa, epct, noner, injury, psych, alcohol, drug)
           when edcnnpa then 'edcnnpa'
           when edcnpa then 'edcnpa'

--- a/models/mart/_models.yml
+++ b/models/mart/_models.yml
@@ -1,9 +1,9 @@
 version: 2
 
 models:
-  - name: ed_summary
+  - name: by_year
     description: >
-      ED Classification as a cube that can be summarized
+      Total Claims and Claim Paid Amount Sum in each category
     config:
       materialized: table
     columns:

--- a/models/mart/by_ccs_description.sql
+++ b/models/mart/by_ccs_description.sql
@@ -1,0 +1,24 @@
+-- {{ config(enabled=var('ed_classification_enabled',var('tuva_packages_enabled',True))) }}
+
+with summary as (
+   select
+      classification_order
+      , classification_name
+      , condition_date_year
+      , ccs_description_with_covid
+      , sum(claim_count) as claim_count
+      , sum(claim_paid_amount_sum) as claim_paid_amount_sum
+
+   from {{ ref('ed_summary') }}
+   group by 1,2,3
+)
+
+select
+    summary.*
+    , 100 * ratio_to_report(claim_count)
+       over(partition by classification_name) as percent_claim_count_of_classification
+    , 100 * ratio_to_report(claim_paid_amount_sum)
+       over(partition by classification_name) as percent_claim_paid_amount_sum_of_classification
+
+from summary
+order by 6 desc

--- a/models/mart/by_year.sql
+++ b/models/mart/by_year.sql
@@ -1,0 +1,23 @@
+-- {{ config(enabled=var('ed_classification_enabled',var('tuva_packages_enabled',True))) }}
+
+with summary as (
+   select
+      classification_order
+      , classification_name
+      , condition_date_year
+      , sum(claim_count) as claim_count
+      , sum(claim_paid_amount_sum) as claim_paid_amount_sum
+
+   from {{ ref('ed_summary') }}
+   group by 1,2,3
+)
+
+select
+    summary.*
+    , 100 * ratio_to_report(claim_count)
+      over(partition by classification_name) as percent_claim_count_of_classification
+    , 100 * ratio_to_report(claim_paid_amount_sum)
+       over(partition by classification_name) as percent_claim_paid_amount_sum_of_classification
+
+from summary
+order by 3 desc

--- a/models/mart/by_year_month.sql
+++ b/models/mart/by_year_month.sql
@@ -1,0 +1,23 @@
+-- {{ config(enabled=var('ed_classification_enabled',var('tuva_packages_enabled',True))) }}
+
+with summary as (
+   select
+      classification_order
+      , classification_name
+      , condition_date_year_month
+      , sum(claim_count) as claim_count
+      , sum(claim_paid_amount_sum) as claim_paid_amount_sum
+
+   from {{ ref('ed_summary') }}
+   group by 1,2,3
+)
+
+select
+    summary.*
+    , 100 * ratio_to_report(claim_count)
+       over(partition by classification_name) as percent_claim_count_of_classification
+    , 100 * ratio_to_report(claim_paid_amount_sum)
+       over(partition by classification_name) as percent_claim_paid_amount_sum_of_classification
+
+from summary
+order by 3 desc

--- a/models/staging/ed_classification__stg_condition.sql
+++ b/models/staging/ed_classification__stg_condition.sql
@@ -11,7 +11,7 @@ with ed_claims as (
     claim_id
     , sum(paid_amount) as claim_paid_amount_sum
   from {{ var('medical_claim') }}
-  where place_of_service_code = '23' or revenue_center_code in ('0450', '0451', '0452', '0459', '0981')
+  where place_of_service_code = '23' or revenue_center_code in ('0450', '0451', '0452', '0456', '0459', '0981')
   group by 1
 )
 
@@ -28,6 +28,7 @@ select
             else mapping.ccs_description
            end
           as {{ dbt.type_string() }}) as ccs_description_with_covid
+   , condition_date
    , cast(claim_paid_amount_sum as {{ dbt.type_float() }}) as claim_paid_amount_sum
 from {{ var('condition') }} condition
 inner join ed_claims using(claim_id)

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,5 @@
+packages:
+  - package: calogica/dbt_date
+    version: [">=0.7.0", "<0.8.0"]
+  - package: dbt-labs/dbt_utils
+    version: 1.0.0

--- a/seeds/ed_classification_categories.csv
+++ b/seeds/ed_classification_categories.csv
@@ -1,10 +1,10 @@
-classification,classification_name,classification_order
-edcnnpa,"Emergent, ED Care Needed, Not Preventable/Avoidable",4
-noner,"Non-Emergent",1
-injury,"Injury",5
-epct,"Emergent, Primary Care Treatable",2
-edcnpa,"Emergent, ED Care Needed, Preventable/Avoidable",3
-psych,"Mental Health Related",6
-alcohol,"Alcohol Related",7
-drug,"Drug Related (excluding alcohol)",8
-unclassified,"Not in a Special Category, and Not Classified",9
+classification,classification_name,classification_order,classification_column
+edcnnpa,"Emergent, ED Care Needed, Not Preventable/Avoidable",4,emergent_ed_not_preventable
+noner,"Non-Emergent",1,non_emergent
+injury,"Injury",5,injury
+epct,"Emergent, Primary Care Treatable",2,emergent_primary_care
+edcnpa,"Emergent, ED Care Needed, Preventable/Avoidable",3,emergent_ed_preventable
+psych,"Mental Health Related",6,mental_health
+alcohol,"Alcohol Related",7,alcohol
+drug,"Drug Related (excluding alcohol)",8,drug
+unclassified,"Not in a Special Category, and Not Classified",9,unclassified


### PR DESCRIPTION
## Describe your changes
_Please include a summary of any changes._
This PR adds a summary cube called `ed_summary` and several time-based views on top of that. One view is by time and ccs_description. Here's an example of how to use it.

## Issues
_Please include any relevant issues as bullets._
- fixes https://github.com/tuva-health/ed_classification/issues/14 

## How has this been tested?
_Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output._
- `dbt run`
```
(tuva) lpanda@Lipsas-MacBook-Pro-2 ed_classification % dbt run
20:56:40  Running with dbt=1.4.5
20:56:40  Found 9 models, 5 tests, 0 snapshots, 0 analyses, 522 macros, 0 operations, 3 seed files, 0 sources, 0 exposures, 0 metrics
20:56:40
20:56:42  Concurrency: 4 threads (target='dev')
20:56:42
20:56:42  1 of 9 START sql view model dbt_lipsa.ed_classification__stg_condition ......... [RUN]
20:56:43  1 of 9 OK created sql view model dbt_lipsa.ed_classification__stg_condition .... [SUCCESS 1 in 0.76s]
20:56:43  2 of 9 START sql view model dbt_lipsa.ed_classification__johnston .............. [RUN]
20:56:44  2 of 9 OK created sql view model dbt_lipsa.ed_classification__johnston ......... [SUCCESS 1 in 0.74s]
20:56:44  3 of 9 START sql table model dbt_lipsa.ed_classification__johnston_conditions_with_class  [RUN]
20:56:44  4 of 9 START sql table model dbt_lipsa.ed_classification_unclassified_report ... [RUN]
20:56:54  4 of 9 OK created sql table model dbt_lipsa.ed_classification_unclassified_report  [SUCCESS 1 in 10.53s]
20:56:58  3 of 9 OK created sql table model dbt_lipsa.ed_classification__johnston_conditions_with_class  [SUCCESS 1 in 13.86s]
20:56:58  5 of 9 START sql table model dbt_lipsa.ed_summary .............................. [RUN]
20:57:01  5 of 9 OK created sql table model dbt_lipsa.ed_summary ......................... [SUCCESS 1 in 3.24s]
20:57:01  6 of 9 START sql view model dbt_lipsa.by_ccs_description ....................... [RUN]
20:57:01  7 of 9 START sql view model dbt_lipsa.by_classification ........................ [RUN]
20:57:01  8 of 9 START sql view model dbt_lipsa.by_year .................................. [RUN]
20:57:01  9 of 9 START sql view model dbt_lipsa.by_year_month ............................ [RUN]
20:57:02  7 of 9 OK created sql view model dbt_lipsa.by_classification ................... [SUCCESS 1 in 0.76s]
20:57:02  6 of 9 OK created sql view model dbt_lipsa.by_ccs_description .................. [SUCCESS 1 in 1.03s]
20:57:02  9 of 9 OK created sql view model dbt_lipsa.by_year_month ....................... [SUCCESS 1 in 1.03s]
20:57:02  8 of 9 OK created sql view model dbt_lipsa.by_year ............................. [SUCCESS 1 in 1.05s]
20:57:02
20:57:02  Finished running 6 view models, 3 table models in 0 hours 0 minutes and 21.53 seconds (21.53s).
20:57:02
20:57:02  Completed successfully
20:57:02
20:57:02  Done. PASS=9 WARN=0 ERROR=0 SKIP=0 TOTAL=9
```

## Reviewer focus
_Please summarize the specific items you’d like the reviewer(s) to look into._
- please review the dimensions used to summarize ed classification and the metrics in the `mart/` models. please suggest alternative dimensions on which to cut the data

## Checklist before requesting a review
- [ ]  (Optional) I have recorded a Loom performing a self-review of my code
- [ ]  My code follows style guidelines
- [ ]  I have commented my code as necessary
- [ ]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have added at least one Github label to this PR

## Loom link
[Loom Video]()
